### PR TITLE
Adjust default Renovate config and add Renovate linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,32 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
   workflow_dispatch:
 
 jobs:
-  lint:
+  markdown:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
+      - name: 🧼 lint markdown files
+        uses: avto-dev/markdown-lint@v1.5.0
 
-      - name: json-lint
+  json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint json files
         uses: ocular-d/json-linter@0.0.2
 
-      - name: markdown-lint
-        uses: avto-dev/markdown-lint@v1.5.0
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint renovate config
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
+        with:
+          config_file_path: "renovate.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2022-10-2
+
+Initial release.
+
+See the [README](Readme.md) for more information.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # renovate-config
 A [shareable config](https://docs.renovatebot.com/config-presets/) for [Renovate](https://docs.renovatebot.com/).
+
+## About
+A shereable Renovate config with some simple grouping by package managers and update types to keep pull request counts down. It also applies some helpful labels depending on the updates being performed. This preset configures Renovate to run just before the weekend. 
+
+See the [CHANGELOG](CHANGELOG.md) for more information and updates.

--- a/default.json
+++ b/default.json
@@ -1,40 +1,60 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration for Gossip",
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
   "extends": [
     "config:base"
   ],
+  "schedule": [
+    "before 9am on Friday"
+  ],
   "packageRules": [
     {
-      "automerge": true,
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "labels": [
-        "dependencies",
-        "non-breaking",
-        "renovate"
+      "matchManagers": [
+        "github-actions"
       ],
-      "matchPackagePatterns": [
-        "*"
+      "groupName": "GitHub Actions",
+      "addLabels": [
+        "actions"
+      ]
+    },
+    {
+      "matchManagers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "groupName": "Docker",
+      "addLabels": [
+        "docker"
+      ]
+    },
+    {
+      "matchManagers": [
+        "nuget"
       ],
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ]
+      ],
+      "addLabels": [
+        "non-breaking"
+      ],
+      "groupName": "NuGet Packages - Minor Updates"
     },
     {
-      "groupName": "all major dependencies",
-      "groupSlug": "all-major",
-      "labels": [
-        "breaking",
-        "dependencies",
-        "renovate"
-      ],
-      "matchPackagePatterns": [
-        "*"
+      "matchManagers": [
+        "nuget"
       ],
       "matchUpdateTypes": [
         "major"
-      ]
+      ],
+      "addLabels": [
+        "breaking"
+      ],
+      "groupName": "NuGet Packages - Major Updates"
     }
   ]
 }


### PR DESCRIPTION
- Adjust the default Renovate configuration to include some nice groupings based on package manager and update types.
- Add a CHANGELOG to keep track of changes.
- Add Renovate linting.